### PR TITLE
Refactor document conversion examples to manage documents inline

### DIFF
--- a/examples/documentation/src/main/java/com/aspose/pdf/examples/convertpdfdocument/PdfToExcelExamples.java
+++ b/examples/documentation/src/main/java/com/aspose/pdf/examples/convertpdfdocument/PdfToExcelExamples.java
@@ -13,51 +13,65 @@ public final class PdfToExcelExamples {
     }
 
     public static void convertPdfToExcelSpreadSheet2003(Path inputFile, Path outputFile) {
-        ExcelSaveOptions saveOptions = new ExcelSaveOptions();
-        saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.XMLSpreadSheet2003);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            ExcelSaveOptions saveOptions = new ExcelSaveOptions();
+            saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.XMLSpreadSheet2003);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToExcel2007(Path inputFile, Path outputFile) {
-        ExcelSaveOptions saveOptions = new ExcelSaveOptions();
-        saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.XLSX);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            ExcelSaveOptions saveOptions = new ExcelSaveOptions();
+            saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.XLSX);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToExcel2007ControlColumn(Path inputFile, Path outputFile) {
-        ExcelSaveOptions saveOptions = new ExcelSaveOptions();
-        saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.XLSX);
-        saveOptions.setInsertBlankColumnAtFirst(true);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            ExcelSaveOptions saveOptions = new ExcelSaveOptions();
+            saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.XLSX);
+            saveOptions.setInsertBlankColumnAtFirst(true);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToExcel2007SingleExcelWorksheet(Path inputFile, Path outputFile) {
-        ExcelSaveOptions saveOptions = new ExcelSaveOptions();
-        saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.XLSX);
-        saveOptions.setMinimizeTheNumberOfWorksheets(true);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            ExcelSaveOptions saveOptions = new ExcelSaveOptions();
+            saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.XLSX);
+            saveOptions.setMinimizeTheNumberOfWorksheets(true);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToExcel2007Macro(Path inputFile, Path outputFile) {
-        ExcelSaveOptions saveOptions = new ExcelSaveOptions();
-        saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.XLSM);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            ExcelSaveOptions saveOptions = new ExcelSaveOptions();
+            saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.XLSM);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToExcel2007Csv(Path inputFile, Path outputFile) {
-        ExcelSaveOptions saveOptions = new ExcelSaveOptions();
-        saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.CSV);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            ExcelSaveOptions saveOptions = new ExcelSaveOptions();
+            saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.CSV);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToOds(Path inputFile, Path outputFile) {
-        ExcelSaveOptions saveOptions = new ExcelSaveOptions();
-        saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.ODS);
-        saveDocument(inputFile, outputFile, saveOptions);
-    }
-
-    private static void saveDocument(Path inputFile, Path outputFile, ExcelSaveOptions saveOptions) {
         try (Document document = new Document(inputFile.toString())) {
+            ExcelSaveOptions saveOptions = new ExcelSaveOptions();
+            saveOptions.setFormat(ExcelSaveOptions.ExcelFormat.ODS);
             document.save(outputFile.toString(), saveOptions);
         }
         System.out.println(inputFile + " converted into " + outputFile);

--- a/examples/documentation/src/main/java/com/aspose/pdf/examples/convertpdfdocument/PdfToHtmlExamples.java
+++ b/examples/documentation/src/main/java/com/aspose/pdf/examples/convertpdfdocument/PdfToHtmlExamples.java
@@ -13,62 +13,83 @@ public final class PdfToHtmlExamples {
     }
 
     public static void convertPdfToHtml(Path inputFile, Path outputFile) {
-        saveDocument(inputFile, outputFile, new HtmlSaveOptions());
+        try (Document document = new Document(inputFile.toString())) {
+            HtmlSaveOptions saveOptions = new HtmlSaveOptions();
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToHtmlStoringImages(Path inputFile, Path outputFile) {
-        HtmlSaveOptions saveOptions = new HtmlSaveOptions();
-        saveOptions.setSpecialFolderForAllImages(inputFile.getParent().resolve("images").toString());
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            HtmlSaveOptions saveOptions = new HtmlSaveOptions();
+            saveOptions.setSpecialFolderForAllImages(inputFile.getParent().resolve("images").toString());
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToHtmlMultiPage(Path inputFile, Path outputFile) {
-        HtmlSaveOptions saveOptions = new HtmlSaveOptions();
-        saveOptions.setSplitIntoPages(true);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            HtmlSaveOptions saveOptions = new HtmlSaveOptions();
+            saveOptions.setSplitIntoPages(true);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToHtmlStoringSvg(Path inputFile, Path outputFile) {
-        HtmlSaveOptions saveOptions = new HtmlSaveOptions();
-        saveOptions.setSpecialFolderForSvgImages(inputFile.getParent().resolve("svg_images").toString());
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            HtmlSaveOptions saveOptions = new HtmlSaveOptions();
+            saveOptions.setSpecialFolderForSvgImages(inputFile.getParent().resolve("svg_images").toString());
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToHtmlCompressSvg(Path inputFile, Path outputFile) {
-        HtmlSaveOptions saveOptions = new HtmlSaveOptions();
-        saveOptions.setSpecialFolderForSvgImages(inputFile.getParent().resolve("svg_images").toString());
-        saveOptions.setCompressSvgGraphicsIfAny(true);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            HtmlSaveOptions saveOptions = new HtmlSaveOptions();
+            saveOptions.setSpecialFolderForSvgImages(inputFile.getParent().resolve("svg_images").toString());
+            saveOptions.setCompressSvgGraphicsIfAny(true);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToHtmlPngBackground(Path inputFile, Path outputFile) {
-        HtmlSaveOptions saveOptions = new HtmlSaveOptions();
-        saveOptions.setRasterImagesSavingMode(HtmlSaveOptions.RasterImagesSavingModes.AsEmbeddedPartsOfPngPageBackground);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            HtmlSaveOptions saveOptions = new HtmlSaveOptions();
+            saveOptions.setRasterImagesSavingMode(HtmlSaveOptions.RasterImagesSavingModes.AsEmbeddedPartsOfPngPageBackground);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToHtmlBodyContent(Path inputFile, Path outputFile) {
-        HtmlSaveOptions saveOptions = new HtmlSaveOptions();
-        saveOptions.setHtmlMarkupGenerationMode(HtmlSaveOptions.HtmlMarkupGenerationModes.WriteOnlyBodyContent);
-        saveOptions.setSplitIntoPages(true);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            HtmlSaveOptions saveOptions = new HtmlSaveOptions();
+            saveOptions.setHtmlMarkupGenerationMode(HtmlSaveOptions.HtmlMarkupGenerationModes.WriteOnlyBodyContent);
+            saveOptions.setSplitIntoPages(true);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToHtmlTransparentTextRendering(Path inputFile, Path outputFile) {
-        HtmlSaveOptions saveOptions = new HtmlSaveOptions();
-        saveOptions.setSaveTransparentTexts(true);
-        saveOptions.setSaveShadowedTextsAsTransparentTexts(true);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            HtmlSaveOptions saveOptions = new HtmlSaveOptions();
+            saveOptions.setSaveTransparentTexts(true);
+            saveOptions.setSaveShadowedTextsAsTransparentTexts(true);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToHtmlDocumentLayersRendering(Path inputFile, Path outputFile) {
-        HtmlSaveOptions saveOptions = new HtmlSaveOptions();
-        saveOptions.setConvertMarkedContentToLayers(true);
-        saveDocument(inputFile, outputFile, saveOptions);
-    }
-
-    private static void saveDocument(Path inputFile, Path outputFile, HtmlSaveOptions saveOptions) {
         try (Document document = new Document(inputFile.toString())) {
+            HtmlSaveOptions saveOptions = new HtmlSaveOptions();
+            saveOptions.setConvertMarkedContentToLayers(true);
             document.save(outputFile.toString(), saveOptions);
         }
         System.out.println(inputFile + " converted into " + outputFile);

--- a/examples/documentation/src/main/java/com/aspose/pdf/examples/convertpdfdocument/PdfToPowerPointExamples.java
+++ b/examples/documentation/src/main/java/com/aspose/pdf/examples/convertpdfdocument/PdfToPowerPointExamples.java
@@ -13,23 +13,26 @@ public final class PdfToPowerPointExamples {
     }
 
     public static void convertPdfToPptx(Path inputFile, Path outputFile) {
-        saveDocument(inputFile, outputFile, new PptxSaveOptions());
+        try (Document document = new Document(inputFile.toString())) {
+            PptxSaveOptions saveOptions = new PptxSaveOptions();
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToPptxSlidesAsImages(Path inputFile, Path outputFile) {
-        PptxSaveOptions saveOptions = new PptxSaveOptions();
-        saveOptions.setSlidesAsImages(true);
-        saveDocument(inputFile, outputFile, saveOptions);
+        try (Document document = new Document(inputFile.toString())) {
+            PptxSaveOptions saveOptions = new PptxSaveOptions();
+            saveOptions.setSlidesAsImages(true);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
     }
 
     public static void convertPdfToPptxImageResolution(Path inputFile, Path outputFile) {
-        PptxSaveOptions saveOptions = new PptxSaveOptions();
-        saveOptions.setImageResolution(300);
-        saveDocument(inputFile, outputFile, saveOptions);
-    }
-
-    private static void saveDocument(Path inputFile, Path outputFile, PptxSaveOptions saveOptions) {
         try (Document document = new Document(inputFile.toString())) {
+            PptxSaveOptions saveOptions = new PptxSaveOptions();
+            saveOptions.setImageResolution(300);
             document.save(outputFile.toString(), saveOptions);
         }
         System.out.println(inputFile + " converted into " + outputFile);

--- a/examples/documentation/src/main/java/com/aspose/pdf/examples/convertpdfdocument/PdfToWordExamples.java
+++ b/examples/documentation/src/main/java/com/aspose/pdf/examples/convertpdfdocument/PdfToWordExamples.java
@@ -12,27 +12,78 @@ public final class PdfToWordExamples {
     private PdfToWordExamples() {
     }
 
+    /**
+     * Convert a PDF document to the legacy Microsoft Word DOC format.
+     */
     public static void convertPdfToDoc(Path inputFile, Path outputFile) {
-        DocSaveOptions saveOptions = new DocSaveOptions();
-        saveOptions.setFormat(DocSaveOptions.DocFormat.Doc);
-        saveDocument(inputFile, outputFile, saveOptions);
-    }
-
-    public static void convertPdfToDocx(Path inputFile, Path outputFile) {
-        DocSaveOptions saveOptions = new DocSaveOptions();
-        saveOptions.setFormat(DocSaveOptions.DocFormat.DocX);
-        saveDocument(inputFile, outputFile, saveOptions);
-    }
-
-    public static void convertPdfToDocxAdvanced(Path inputFile, Path outputFile) {
-        DocSaveOptions saveOptions = new DocSaveOptions();
-        saveOptions.setFormat(DocSaveOptions.DocFormat.DocX);
-        saveOptions.setMode(DocSaveOptions.RecognitionMode.EnhancedFlow);
-        saveDocument(inputFile, outputFile, saveOptions);
-    }
-
-    private static void saveDocument(Path inputFile, Path outputFile, DocSaveOptions saveOptions) {
         try (Document document = new Document(inputFile.toString())) {
+            DocSaveOptions saveOptions = new DocSaveOptions();
+            saveOptions.setFormat(DocSaveOptions.DocFormat.Doc);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
+    }
+
+    /**
+     * Convert a PDF document to the Microsoft Word DOCX format.
+     */
+    public static void convertPdfToDocx(Path inputFile, Path outputFile) {
+        try (Document document = new Document(inputFile.toString())) {
+            DocSaveOptions saveOptions = new DocSaveOptions();
+            saveOptions.setFormat(DocSaveOptions.DocFormat.DocX);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
+    }
+
+    /**
+     * Convert a PDF document to DOCX by using enhanced flow recognition.
+     */
+    public static void convertPdfToDocxAdvanced(Path inputFile, Path outputFile) {
+        try (Document document = new Document(inputFile.toString())) {
+            DocSaveOptions saveOptions = new DocSaveOptions();
+            saveOptions.setFormat(DocSaveOptions.DocFormat.DocX);
+            saveOptions.setMode(DocSaveOptions.RecognitionMode.EnhancedFlow);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
+    }
+
+    /**
+     * Convert a PDF document to DOCX and preserve line breaks from the source file.
+     */
+    public static void convertPdfToDocxWithLineBreaks(Path inputFile, Path outputFile) {
+        try (Document document = new Document(inputFile.toString())) {
+            DocSaveOptions saveOptions = new DocSaveOptions();
+            saveOptions.setFormat(DocSaveOptions.DocFormat.DocX);
+            saveOptions.setAddReturnToLineEnd(true);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
+    }
+
+    /**
+     * Convert a PDF document to DOCX and recognize bullet lists during conversion.
+     */
+    public static void convertPdfToDocxWithBulletRecognition(Path inputFile, Path outputFile) {
+        try (Document document = new Document(inputFile.toString())) {
+            DocSaveOptions saveOptions = new DocSaveOptions();
+            saveOptions.setFormat(DocSaveOptions.DocFormat.DocX);
+            saveOptions.setRecognizeBullets(true);
+            document.save(outputFile.toString(), saveOptions);
+        }
+        System.out.println(inputFile + " converted into " + outputFile);
+    }
+
+    /**
+     * Convert a PDF document to DOCX and set output image resolution.
+     */
+    public static void convertPdfToDocxWithImageResolution(Path inputFile, Path outputFile) {
+        try (Document document = new Document(inputFile.toString())) {
+            DocSaveOptions saveOptions = new DocSaveOptions();
+            saveOptions.setFormat(DocSaveOptions.DocFormat.DocX);
+            saveOptions.setImageResolutionX(300);
+            saveOptions.setImageResolutionY(300);
             document.save(outputFile.toString(), saveOptions);
         }
         System.out.println(inputFile + " converted into " + outputFile);
@@ -46,6 +97,9 @@ public final class PdfToWordExamples {
         ExampleRunner.run("PDF to DOC", () -> convertPdfToDoc(inputFile, dirs.outputFile("PDF_to_DOC.doc")));
         ExampleRunner.run("PDF to DOCX", () -> convertPdfToDocx(inputFile, dirs.outputFile("PDF_to_DOCX.docx")));
         ExampleRunner.run("PDF to DOCX advanced", () -> convertPdfToDocxAdvanced(inputFile, dirs.outputFile("PDF_to_DOCX_adv.docx")));
+        ExampleRunner.run("PDF to DOCX with line breaks", () -> convertPdfToDocxWithLineBreaks(inputFile, dirs.outputFile("PDF_to_DOCX_line_breaks.docx")));
+        ExampleRunner.run("PDF to DOCX with bullet recognition", () -> convertPdfToDocxWithBulletRecognition(inputFile, dirs.outputFile("PDF_to_DOCX_bullets.docx")));
+        ExampleRunner.run("PDF to DOCX with image resolution", () -> convertPdfToDocxWithImageResolution(inputFile, dirs.outputFile("PDF_to_DOCX_image_res.docx")));
 
         System.out.println();
         System.out.println("All PDF to Word examples finished.");


### PR DESCRIPTION
## Summary
- Refactor PDF conversion examples to open and close `Document` instances directly inside each operation.
- Remove shared helper methods in favor of per-example save logic for HTML, Excel, PowerPoint, and Word conversions.
- Add new PDF-to-Word variants for line breaks, bullet recognition, and image resolution, and register them in the runner.

## Testing
- Not run (not requested)